### PR TITLE
Fixed issue where future versions are marked as outdated

### DIFF
--- a/Sources/Updeto/Updeto.swift
+++ b/Sources/Updeto/Updeto.swift
@@ -128,14 +128,16 @@ public final class Updeto: UpdetoType {
                 self.appId = result.appId
 
                 //return result.version == self.currentAppVersion ? .updated : .outdated
-                if result.version == self.currentAppVersion {
+                switch result.version {
+                case result.version == self.currentAppVersion {
                     return .updated
                 }
-                else if result.version > self.currentAppVersion {
+                case result.version > self.currentAppVersion {
                     return .updated
                 }
-                else {
+                default {
                     return .outdated
+                }
                 }
             }
             .replaceError(with: .noResults)
@@ -160,14 +162,16 @@ public final class Updeto: UpdetoType {
                     DispatchQueue.main.async {
                         completion(
                             //result.version == self.currentAppVersion ? .updated : .outdated
-                            if result.version == self.currentAppVersion {
+                            switch result.version {
+                            case result.version == self.currentAppVersion {
                                 return .updated
                             }
-                            else if result.version > self.currentAppVersion {
+                            case result.version > self.currentAppVersion {
                                 return .updated
                             }
-                            else {
+                            default {
                                 return .outdated
+                            }
                             }
                         )
                     }

--- a/Sources/Updeto/Updeto.swift
+++ b/Sources/Updeto/Updeto.swift
@@ -131,8 +131,11 @@ public final class Updeto: UpdetoType {
                 if result.version == self.currentAppVersion {
                     return .updated
                 }
-                else if result.version < self.currentAppVersion {
+                else if result.version > self.currentAppVersion {
                     return .outdated
+                }
+                else if result.version < self.currentAppVersion {
+                    return .updated
                 }
                 else {
                     return .outdated
@@ -162,8 +165,11 @@ public final class Updeto: UpdetoType {
                             if result.version == self.currentAppVersion {
                                 completion(.updated)
                             }
-                            else if result.version < self.currentAppVersion {
+                            else if result.version > self.currentAppVersion {
                                 completion(.outdated)
+                            }
+                            else if result.version < self.currentAppVersion {
+                                completion(.updated)
                             }
                             else {
                                 completion(.outdated)

--- a/Sources/Updeto/Updeto.swift
+++ b/Sources/Updeto/Updeto.swift
@@ -128,16 +128,14 @@ public final class Updeto: UpdetoType {
                 self.appId = result.appId
 
                 //return result.version == self.currentAppVersion ? .updated : .outdated
-                switch result.version {
-                case result.version == self.currentAppVersion {
+                if result.version == self.currentAppVersion {
                     return .updated
                 }
-                case result.version > self.currentAppVersion {
+                else if result.version > self.currentAppVersion {
                     return .updated
                 }
-                default {
+                else {
                     return .outdated
-                }
                 }
             }
             .replaceError(with: .noResults)
@@ -160,20 +158,16 @@ public final class Updeto: UpdetoType {
                     self.appId = result.appId
 
                     DispatchQueue.main.async {
-                        completion(
                             //result.version == self.currentAppVersion ? .updated : .outdated
-                            switch result.version {
-                            case result.version == self.currentAppVersion {
-                                return .updated
+                            if result.version == self.currentAppVersion {
+                                completion(.updated)
                             }
-                            case result.version > self.currentAppVersion {
-                                return .updated
+                            else if result.version > self.currentAppVersion {
+                                completion(.updated)
                             }
-                            default {
-                                return .outdated
+                            else {
+                                completion(.outdated)
                             }
-                            }
-                        )
                     }
                 } else {
                     DispatchQueue.main.async {

--- a/Sources/Updeto/Updeto.swift
+++ b/Sources/Updeto/Updeto.swift
@@ -131,7 +131,7 @@ public final class Updeto: UpdetoType {
                 if result.version == self.currentAppVersion {
                     return .updated
                 }
-                else if result.version > self.currentAppVersion {
+                else if result.version < self.currentAppVersion {
                     return .outdated
                 }
                 else {
@@ -162,7 +162,7 @@ public final class Updeto: UpdetoType {
                             if result.version == self.currentAppVersion {
                                 completion(.updated)
                             }
-                            else if result.version > self.currentAppVersion {
+                            else if result.version < self.currentAppVersion {
                                 completion(.outdated)
                             }
                             else {

--- a/Sources/Updeto/Updeto.swift
+++ b/Sources/Updeto/Updeto.swift
@@ -127,7 +127,16 @@ public final class Updeto: UpdetoType {
 
                 self.appId = result.appId
 
-                return result.version == self.currentAppVersion ? .updated : .outdated
+                //return result.version == self.currentAppVersion ? .updated : .outdated
+                if result.version == self.currentAppVersion {
+                    return .updated
+                }
+                else if result.version > self.currentAppVersion {
+                    return .updated
+                }
+                else {
+                    return .outdated
+                }
             }
             .replaceError(with: .noResults)
             .eraseToAnyPublisher()

--- a/Sources/Updeto/Updeto.swift
+++ b/Sources/Updeto/Updeto.swift
@@ -132,7 +132,7 @@ public final class Updeto: UpdetoType {
                     return .updated
                 }
                 else if result.version > self.currentAppVersion {
-                    return .updated
+                    return .outdated
                 }
                 else {
                     return .outdated
@@ -163,7 +163,7 @@ public final class Updeto: UpdetoType {
                                 completion(.updated)
                             }
                             else if result.version > self.currentAppVersion {
-                                completion(.updated)
+                                completion(.outdated)
                             }
                             else {
                                 completion(.outdated)

--- a/Sources/Updeto/Updeto.swift
+++ b/Sources/Updeto/Updeto.swift
@@ -150,7 +150,16 @@ public final class Updeto: UpdetoType {
 
                     DispatchQueue.main.async {
                         completion(
-                            result.version == self.currentAppVersion ? .updated : .outdated
+                            //result.version == self.currentAppVersion ? .updated : .outdated
+                            if result.version == self.currentAppVersion {
+                                return .updated
+                            }
+                            else if result.version > self.currentAppVersion {
+                                return .updated
+                            }
+                            else {
+                                return .outdated
+                            }
                         )
                     }
                 } else {


### PR DESCRIPTION
Hello, I fixed the issue where future versions are marked as outdated. I did this by returning or using completion with an if statement to see if the version is either equal to the current version, less than the current version, or greater than the current version.